### PR TITLE
Joxyfile is for Javadoc, just like Doxyfile is for Doxygen.

### DIFF
--- a/Joxyfile
+++ b/Joxyfile
@@ -1,0 +1,23 @@
+#
+# Joxyfile
+# =============================================================================
+# The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
+# Microservice. Version 0.0.1
+# =============================================================================
+# This is the Javadoc configuration for the project,
+# used to automatically generate API documentation
+# from source code.
+#
+
+# === Packages ================================================================
+com.minimization.nonlinear.unconstrained.hookejeeves
+
+# === Options =================================================================
+-sourcepath   src/main/java/
+-d            docs/api
+-nodeprecated
+-nohelp
+-windowtitle  "The Hooke and Jeeves NLP algorithm. Microservice API"
+-header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.0.1)</b>"
+
+# vim:set nu et ts=4 sw=4:

--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ $ curl -vd '' http://localhost:8080/solve?fx=woods
 **Generate** API documentation:
 
 ```
-$ javadoc com.minimization.nonlinear.unconstrained.hookejeeves                           \
-         -sourcepath   src/main/java/                                                    \
-         -d            docs/api                                                          \
-         -nodeprecated                                                                   \
-         -nohelp                                                                         \
-         -windowtitle  "The Hooke and Jeeves NLP algorithm. Microservice API"            \
-         -header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.0.1)</b>"
+$ javadoc @Joxyfile
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ $ curl -vd '' http://localhost:8080/solve?fx=woods
 ...
 ```
 
-Generate API documentation:
+**Generate** API documentation:
 
 ```
-$ javadoc com.minimization.nonlinear.unconstrained.hookejeeves \
-                                    -sourcepath src/main/java/ \
-                                    -d          docs/api
+$ javadoc com.minimization.nonlinear.unconstrained.hookejeeves                           \
+         -sourcepath   src/main/java/                                                    \
+         -d            docs/api                                                          \
+         -nodeprecated                                                                   \
+         -nohelp                                                                         \
+         -windowtitle  "The Hooke and Jeeves NLP algorithm. Microservice API"            \
+         -header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.0.1)</b>"
 ...
 ```


### PR DESCRIPTION
- Adding extra flags and options to the **Javadoc** input for getting rid of unnecessary navigational sections and giving a documentation consolidated titles.
- Bringing out **Javadoc** parameters to **Joxyfile**.