### PR TITLE
Return a compound response POJO: with the "inputs" POJO inside it.

### DIFF
--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -393,15 +393,8 @@ public class HookeJeevesController {
             System.out.println("True answer: f(1, 1, 1, 1) = 0.");
         }
 
-        HookeJeevesResponsePojo resp_body = null;
-
-               if (fx.compareTo(ROSENBROCK) == 0) {
-            resp_body = new HookeJeevesResponsePojo(
-                nvars, startpt[0], startpt[1], rho);
-        } else if (fx.compareTo(WOODS     ) == 0) {
-            resp_body = new HookeJeevesResponsePojo(
-                nvars, startpt[0], startpt[1], startpt[2], startpt[3], rho);
-        }
+        HookeJeevesResponsePojo resp_body
+            = new HookeJeevesResponsePojo(nvars, startpt, rho);
 
         return new ResponseEntity(resp_body, HttpStatus.OK);
     }

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -393,8 +393,8 @@ public class HookeJeevesController {
             System.out.println("True answer: f(1, 1, 1, 1) = 0.");
         }
 
-        HookeJeevesResponsePojo resp_body
-            = new HookeJeevesResponsePojo(nvars, startpt, rho);
+        HookeJeevesResponsePojo resp_body = new HookeJeevesResponsePojo(
+            new HookeJeevesResponsePojoInputs(nvars, startpt, rho));
 
         return new ResponseEntity(resp_body, HttpStatus.OK);
     }

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
@@ -26,17 +26,8 @@ public class HookeJeevesResponsePojo {
     /** The number of variables. */
     private final int nvars;
 
-    /** The 1st starting point coordinate. */
-    private final double startpt0;
-
-    /** The 2nd starting point coordinate. */
-    private final double startpt1;
-
-    /** The 3rd starting point coordinate. */
-    private final double startpt2;
-
-    /** The 4th starting point coordinate. */
-    private final double startpt3;
+    /** The starting point coordinates. */
+    private final double[] startpt;
 
     /** The rho value. */
     private final double rho;
@@ -51,39 +42,12 @@ public class HookeJeevesResponsePojo {
     }
 
     /**
-     * The accessor method for the 1st starting point coordinate.
+     * The accessor method for the starting point coordinates.
      *
-     * @return The 1st starting point coordinate.
+     * @return The array of starting point coordinates.
      */
-    public double getStartpt0() {
-        return startpt0;
-    }
-
-    /**
-     * The accessor method for the 2nd starting point coordinate.
-     *
-     * @return The 2nd starting point coordinate.
-     */
-    public double getStartpt1() {
-        return startpt1;
-    }
-
-    /**
-     * The accessor method for the 3rd starting point coordinate.
-     *
-     * @return The 3rd starting point coordinate.
-     */
-    public double getStartpt2() {
-        return startpt2;
-    }
-
-    /**
-     * The accessor method for the 4th starting point coordinate.
-     *
-     * @return The 4th starting point coordinate.
-     */
-    public double getStartpt3() {
-        return startpt3;
+    public double[] getStartpt() {
+        return startpt;
     }
 
     /**
@@ -96,55 +60,23 @@ public class HookeJeevesResponsePojo {
     }
 
     /**
-     * Constructs the response object for two starting point coordinates.
-     * <br />
-     * <br />This is commonly effective when the objective function
-     * is the Rosenbrock's parabolic valley function.
+     * Constructs the response object.
      *
-     * @param _nvars    The number of variables.
-     * @param _startpt0 The 1st starting point coordinate.
-     * @param _startpt1 The 2nd starting point coordinate.
-     * @param _rho      The rho value.
+     * @param _nvars   The number of variables.
+     * @param _startpt The starting point coordinates.
+     * @param _rho     The rho value.
      */
-    public HookeJeevesResponsePojo(final int    _nvars,
-                                   final double _startpt0,
-                                   final double _startpt1,
-                                   final double _rho) {
+    public HookeJeevesResponsePojo(final int      _nvars,
+                                   final double[] _startpt,
+                                   final double   _rho) {
 
-        nvars    = _nvars;
-        startpt0 = _startpt0;
-        startpt1 = _startpt1;
-        startpt2 = .0;
-        startpt3 = .0;
-        rho      = _rho;
-    }
+        nvars   = _nvars;
+        startpt = new double[nvars];
+        rho     = _rho;
 
-    /**
-     * Constructs the response object for four starting point coordinates.
-     * <br />
-     * <br />This is commonly effective when the objective function
-     * is the so-called &quot;Woods&quot; function.
-     *
-     * @param _nvars    The number of variables.
-     * @param _startpt0 The 1st starting point coordinate.
-     * @param _startpt1 The 2nd starting point coordinate.
-     * @param _startpt2 The 3rd starting point coordinate.
-     * @param _startpt3 The 4th starting point coordinate.
-     * @param _rho      The rho value.
-     */
-    public HookeJeevesResponsePojo(final int    _nvars,
-                                   final double _startpt0,
-                                   final double _startpt1,
-                                   final double _startpt2,
-                                   final double _startpt3,
-                                   final double _rho) {
-
-        nvars    = _nvars;
-        startpt0 = _startpt0;
-        startpt1 = _startpt1;
-        startpt2 = _startpt2;
-        startpt3 = _startpt3;
-        rho      = _rho;
+        for (int i = 0; i < nvars; i++) {
+            startpt[i] = _startpt[i];
+        }
     }
 }
 

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
@@ -23,60 +23,31 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojo {
-    /** The number of variables. */
-    private final int nvars;
-
-    /** The starting point coordinates. */
-    private final double[] startpt;
-
-    /** The rho value. */
-    private final double rho;
+    /**
+     * The &quot;<code>inputs</code>&quot; POJO,
+     * returning as part of the response POJO.
+     */
+    private final HookeJeevesResponsePojoInputs inputs;
 
     /**
-     * The accessor method for the number of variables.
+     * The accessor method for the &quot;<code>inputs</code>&quot; POJO,
+     * returning as part of the response POJO.
      *
-     * @return The number of variables.
+     * @return The &quot;<code>inputs</code>&quot; POJO,
+     *         returning as part of the response POJO.
      */
-    public int getNvars() {
-        return nvars;
-    }
-
-    /**
-     * The accessor method for the starting point coordinates.
-     *
-     * @return The array of starting point coordinates.
-     */
-    public double[] getStartpt() {
-        return startpt;
-    }
-
-    /**
-     * The accessor method for the rho value.
-     *
-     * @return The rho value.
-     */
-    public double getRho() {
-        return rho;
+    public HookeJeevesResponsePojoInputs getInputs() {
+        return inputs;
     }
 
     /**
      * Constructs the response object.
      *
-     * @param _nvars   The number of variables.
-     * @param _startpt The starting point coordinates.
-     * @param _rho     The rho value.
+     * @param _inputs The &quot;<code>inputs</code>&quot; POJO,
+     *                returning as part of the response POJO.
      */
-    public HookeJeevesResponsePojo(final int      _nvars,
-                                   final double[] _startpt,
-                                   final double   _rho) {
-
-        nvars   = _nvars;
-        startpt = new double[nvars];
-        rho     = _rho;
-
-        for (int i = 0; i < nvars; i++) {
-            startpt[i] = _startpt[i];
-        }
+    public HookeJeevesResponsePojo(final HookeJeevesResponsePojoInputs _inputs) {
+        inputs = _inputs;
     }
 }
 

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
@@ -1,0 +1,85 @@
+/*
+ * src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/
+ * HookeJeevesResponsePojoInputs.java
+ * ============================================================================
+ * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
+ * Microservice. Version 0.6.0
+ * ============================================================================
+ * A Spring Boot-based application, designed and intended to be run
+ * as a microservice, implementing the nonlinear unconstrained
+ * minimization algorithm of Hooke and Jeeves.
+ * ============================================================================
+ * Copyright (C) 2020-2021 Radislav (Radicchio) Golubtsov
+ *
+ * (See the LICENSE file at the top of the source tree.)
+ */
+
+package com.minimization.nonlinear.unconstrained.hookejeeves;
+
+/**
+ * The &quot;<code>inputs</code>&quot; POJO representation,
+ * returning as part of the response POJO.
+ *
+ * @version 0.6.0
+ * @since   0.6.0
+ */
+public class HookeJeevesResponsePojoInputs {
+    /** The number of variables. */
+    private final int nvars;
+
+    /** The starting point coordinates. */
+    private final double[] startpt;
+
+    /** The rho value. */
+    private final double rho;
+
+    /**
+     * The accessor method for the number of variables.
+     *
+     * @return The number of variables.
+     */
+    public int getNvars() {
+        return nvars;
+    }
+
+    /**
+     * The accessor method for the starting point coordinates.
+     *
+     * @return The array of starting point coordinates.
+     */
+    public double[] getStartpt() {
+        return startpt;
+    }
+
+    /**
+     * The accessor method for the rho value.
+     *
+     * @return The rho value.
+     */
+    public double getRho() {
+        return rho;
+    }
+
+    /**
+     * Constructs the &quot;<code>inputs</code>&quot; part
+     * of the response object.
+     *
+     * @param _nvars   The number of variables.
+     * @param _startpt The starting point coordinates.
+     * @param _rho     The rho value.
+     */
+    public HookeJeevesResponsePojoInputs(final int      _nvars,
+                                         final double[] _startpt,
+                                         final double   _rho) {
+
+        nvars   = _nvars;
+        startpt = new double[nvars];
+        rho     = _rho;
+
+        for (int i = 0; i < nvars; i++) {
+            startpt[i] = _startpt[i];
+        }
+    }
+}
+
+// vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Getting rid of restricted set of **scalar** coordinates, naturally holding any number of them in an **array**.
- Using a **uniform constructor** for any objective function (any number of coordinates) when creating successful response body.
- Adding the "`inputs`" POJO representation, returning as part of the response POJO.
- Bringing out all properties and methods to a **separate POJO representation**; instead populating this response POJO with references to the latter.
- Calling the **new compound constructor** of the response POJO.