### PR TITLE
Get the scaling factor for a double-precision value from the object property instead of calling its dedicated helper method on every request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # .gitignore
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # .travis.yml
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/Doxyfile
+++ b/Doxyfile
@@ -2,7 +2,7 @@
 # Doxyfile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained
@@ -53,13 +53,13 @@ PROJECT_NAME           = "The Hooke and Jeeves NLP algorithm. Microservice API"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.7.0
+PROJECT_NUMBER         = 0.7.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Hooke and Jeeves NLP alg. Microservice API (v0.7.0)"
+PROJECT_BRIEF          = "Hooke and Jeeves NLP alg. Microservice API (v0.7.3)"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/Joxyfile
+++ b/Joxyfile
@@ -2,7 +2,7 @@
 # Joxyfile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained
@@ -26,6 +26,6 @@ com.minimization.nonlinear.unconstrained.hookejeeves.algorithm
 -nodeprecated
 -nohelp
 -windowtitle  "The Hooke and Jeeves NLP algorithm. Microservice API"
--header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.7.0)</b>"
+-header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.7.3)</b>"
 
 # vim:set nu et ts=4 sw=4:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ # Whilst this is not necessary, it's beneficial knowing the exit code.
 **Run** the microservice using its all-in-one JAR file, built previously by the `package` or `jar` targets:
 
 ```
-$ java -jar target/hooke-jeeves-0.7.0.jar; echo $?
+$ java -jar target/hooke-jeeves-0.7.3.jar; echo $?
 ...
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  * pom.xml
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -26,7 +26,7 @@
     </parent>
     <groupId>com.minimization.nonlinear.unconstrained</groupId>
     <artifactId>hooke-jeeves</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.3</version>
     <name>Hooke-Jeeves</name>
     <description>The Hooke and Jeeves nonlinear unconstrained minimization algorithm. Microservice.</description>
     <properties>

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
@@ -24,6 +24,8 @@ import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import com.mongodb.reactivestreams.client.MongoCollection;
 
+import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesControllerHelper.*;
+
 /**
  * The startup class of the microservice.
  *
@@ -41,6 +43,9 @@ public class HookeJeevesApp {
     /** The collection object to store data to. */
     public static MongoCollection collection;
 
+    /** The scaling factor for a double-precision value. */
+    public static int scaling_factor;
+
     /**
      * The microservice entry point.
      *
@@ -52,6 +57,10 @@ public class HookeJeevesApp {
         MongoDatabase database = client.getDatabase(TEST_DATABASE);
 
         collection = database.getCollection(INITIAL_DATA_COLL);
+
+        // Getting the scaling factor for a double-precision value
+        // from application properties.
+        scaling_factor = get_scaling_factor();
 
         // Starting up the app.
         SpringApplication.run(HookeJeevesApp.class, args);

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
@@ -3,7 +3,7 @@
  * HookeJeevesApp.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -29,7 +29,7 @@ import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesCo
 /**
  * The startup class of the microservice.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 @SpringBootApplication

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -3,7 +3,7 @@
  * HookeJeevesController.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -44,7 +44,7 @@ import        com.minimization.nonlinear.unconstrained.hookejeeves.algorithm.Woo
 /**
  * The controller class of the microservice.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 @RestController

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -424,11 +424,12 @@ public class HookeJeevesController {
 
         // Scaling down the ending point coordinate values.
         for (i = 0; i < nvars; i++) {
-            endpt[i]=_scale_down_double_value(endpt[i], _get_scaling_factor());
+            endpt[i] = scale_down_double_value(endpt[i],
+                HookeJeevesApp.scaling_factor);
         }
 
         // Scaling down the objective function value.
-        f_x = _scale_down_double_value(f_x, _get_scaling_factor());
+        f_x = scale_down_double_value(f_x, HookeJeevesApp.scaling_factor);
 
         HookeJeevesResponsePojo resp_body = new HookeJeevesResponsePojo(
             new HookeJeevesResponsePojoInputs(nvars, startpt, rho),

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
@@ -263,18 +263,29 @@ public class HookeJeevesControllerHelper {
         }
     }
 
-    // Helper method. Scales down the given double-precision value
-    //                using the specified scaling factor.
-    public static final double _scale_down_double_value(final double value,
-                                                        final int    scale) {
+    /**
+     * Scales down the given double-precision value
+     * using the specified scaling factor.
+     *
+     * @param value The double-precision value to scale it down.
+     * @param scale The scaling factor for the given double-precision value.
+     *
+     * @return The double-precision value, a scaled down one.
+     */
+    public static double scale_down_double_value(final double value,
+                                                 final int    scale) {
 
         return BigDecimal.valueOf(value).setScale((scale > TWELVE) ? TWELVE :
                                   scale, RoundingMode.HALF_UP).doubleValue();
     }
 
-    // Helper method. Retrieves the scaling factor for a double-precision value
-    //                from application properties.
-    public static final int _get_scaling_factor() {
+    /**
+     * Retrieves the scaling factor for a double-precision value
+     * from application properties.
+     *
+     * @return The scaling factor for a double-precision value.
+     */
+    public static int get_scaling_factor() {
         Properties props = _get_props(ERR_DBL_VALUE_SCALE_UNABLE_TO_GET);
 
         String dbl_value_scale = props.getProperty(DBL_VALUE_SCALE);

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
@@ -3,7 +3,7 @@
  * HookeJeevesControllerHelper.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -38,7 +38,7 @@ import org.bson.Document;
 /**
  * The helper class for the controller and the related ones.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 public class HookeJeevesControllerHelper {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojo.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -19,7 +19,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
 /**
  * The POJO representation, returning in the response.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojo {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoError.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoError.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoError.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The POJO representation, returning in the response
  * when erroneous behavior is occurred.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.6.6
  */
 public class HookeJeevesResponsePojoError {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoInputs.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The &quot;<code>inputs</code>&quot; POJO representation,
  * returning as part of the response POJO.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojoInputs {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoOutput.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoOutput.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoOutput.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The &quot;<code>output</code>&quot; POJO representation,
  * returning as part of the response POJO.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojoOutput {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
@@ -3,7 +3,7 @@
  * algorithm/HookeJeeves.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * The <code>HookeJeeves</code> class contains methods for solving a nonlinear
  * optimization problem using the algorithm of Hooke and Jeeves.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 public class HookeJeeves {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Rosenbrock.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Rosenbrock.java
@@ -3,7 +3,7 @@
  * algorithm/Rosenbrock.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -23,7 +23,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * <br />The objective function in this case is the Rosenbrock's parabolic
  * valley function.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 public final class Rosenbrock {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Woods.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Woods.java
@@ -3,7 +3,7 @@
  * algorithm/Woods.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -23,7 +23,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * <br />The objective function in this case is the so-called
  * &quot;Woods&quot; function.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 public final class Woods {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 # src/main/resources/application.properties
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@
 # src/main/resources/log4j.properties
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.0
+# Microservice. Version 0.7.3
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/src/test/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesAppTests.java
+++ b/src/test/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesAppTests.java
@@ -3,7 +3,7 @@
  * HookeJeevesAppTests.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -29,7 +29,7 @@ import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesCo
 /**
  * The test class for the microservice.
  *
- * @version 0.7.0
+ * @version 0.7.3
  * @since   0.0.1
  */
 @SpringBootTest

--- a/static/css/doxygen/html-extra-stylesheet.css
+++ b/static/css/doxygen/html-extra-stylesheet.css
@@ -2,7 +2,7 @@
  * static/css/doxygen/html-extra-stylesheet.css
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.0
+ * Microservice. Version 0.7.3
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained


### PR DESCRIPTION
- Converting helper methods to the ordinary ones.
- Declaring the scaling factor for a double-precision value **on the application level**, and initialize it later on.
- Getting the scaling factor for a double-precision value **from the object property** instead of calling its dedicated helper method on every request.
- Bumping version number of the app to **0.7.3**.