### PR TITLE
Get rid of unused and inactive piece of code.

### DIFF
--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
@@ -64,15 +64,6 @@ public class HookeJeevesApp {
 
         // Starting up the app.
         SpringApplication.run(HookeJeevesApp.class, args);
-
-        // Making final cleanups.
-        _cleanups_fixate(client);
-    }
-
-    // Helper method: Makes final buffer cleanups, releases resources, etc.
-    private static final void _cleanups_fixate(final MongoClient client) {
-        // Closing the database client.
-//      client.close();
     }
 }
 


### PR DESCRIPTION
The `_cleanups_fixate(...)` helper method currently does nothing. It's safe to remove its declaration and its invocation.