### PR TITLE
Attribution: Keep the intermediate debug output in the original format, taken from Netlib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # .gitignore
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # .travis.yml
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/Doxyfile
+++ b/Doxyfile
@@ -2,7 +2,7 @@
 # Doxyfile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained
@@ -53,13 +53,13 @@ PROJECT_NAME           = "The Hooke and Jeeves NLP algorithm. Microservice API"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.7.3
+PROJECT_NUMBER         = 0.7.6
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Hooke and Jeeves NLP alg. Microservice API (v0.7.3)"
+PROJECT_BRIEF          = "Hooke and Jeeves NLP alg. Microservice API (v0.7.6)"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/Joxyfile
+++ b/Joxyfile
@@ -2,7 +2,7 @@
 # Joxyfile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained
@@ -26,6 +26,6 @@ com.minimization.nonlinear.unconstrained.hookejeeves.algorithm.Woods
 -nodeprecated
 -nohelp
 -windowtitle  "The Hooke and Jeeves NLP algorithm. Microservice API"
--header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.7.3)</b>"
+-header       "<b>Hooke and Jeeves NLP alg.<br />Microservice API (v0.7.6)</b>"
 
 # vim:set nu et ts=4 sw=4:

--- a/Joxyfile
+++ b/Joxyfile
@@ -15,8 +15,8 @@
 
 # === Packages ================================================================
 #com.minimization.nonlinear.unconstrained.hookejeeves
-com.minimization.nonlinear.unconstrained.hookejeeves.algorithm
-#com.minimization.nonlinear.unconstrained.hookejeeves.controller
+com.minimization.nonlinear.unconstrained.hookejeeves.algorithm.Rosenbrock
+com.minimization.nonlinear.unconstrained.hookejeeves.algorithm.Woods
 
 # === Options =================================================================
 -sourcepath   src/main/java/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(JAR):
 
 # Making the fourth target (API docs).
 $(API):
-	$(JAVADOC) $(JDFLAGS)
+#	$(JAVADOC) $(JDFLAGS)
 	$(ECHO)
 $(DOX):
 	$(DOXYGEN)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ # Whilst this is not necessary, it's beneficial knowing the exit code.
 **Run** the microservice using its all-in-one JAR file, built previously by the `package` or `jar` targets:
 
 ```
-$ java -jar target/hooke-jeeves-0.7.3.jar; echo $?
+$ java -jar target/hooke-jeeves-0.7.6.jar; echo $?
 ...
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  * pom.xml
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -26,7 +26,7 @@
     </parent>
     <groupId>com.minimization.nonlinear.unconstrained</groupId>
     <artifactId>hooke-jeeves</artifactId>
-    <version>0.7.3</version>
+    <version>0.7.6</version>
     <name>Hooke-Jeeves</name>
     <description>The Hooke and Jeeves nonlinear unconstrained minimization algorithm. Microservice.</description>
     <properties>

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesApp.java
@@ -3,7 +3,7 @@
  * HookeJeevesApp.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -29,7 +29,7 @@ import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesCo
 /**
  * The startup class of the microservice.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 @SpringBootApplication

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -80,6 +80,15 @@ public class HookeJeevesController {
     private static final String SLASH =   "/";
     private static final String _ID   = "_id";
 
+    private static final String NLP_HOOKE_USED = "HOOKE USED";
+    private static final String NLP_ITERATIONS = "ITERATIONS, AND RETURNED";
+    private static final String NLP_X_OPENING_SQR_BRKT = "x[";
+    private static final String NLP_X_CLOSING_SQR_BRKT = "] =";
+    private static final String NLP_FORMAT_3D          = "%3d";
+    private static final String NLP_FORMAT_15_POINT_7E = "%15.7e";
+    private static final String NLP_TRUE_ANSWER = "True answer: "
+        + "f(1, 1, 1, 1) = 0.";
+
     /** The SLF4J logger. */
     private static final Logger l = LoggerFactory.getLogger(
         MethodHandles.lookup().lookupClass()
@@ -401,16 +410,19 @@ public class HookeJeevesController {
         jj = new HookeJeeves()
             .hooke(nvars, startpt, endpt, rho, epsilon, itermax, objfun_cls);
 
-        System.out.println("\n\n\nHOOKE USED " + jj
-                         + " ITERATIONS, AND RETURNED");
+        // Attribution: Keeping the intermediate debug output
+        //              in the original format, taken from Netlib.
+        l.debug(EMPTY_STRING);  l.debug(EMPTY_STRING);  l.debug(EMPTY_STRING);
+        l.debug(NLP_HOOKE_USED + SPACE + BRACES + SPACE + NLP_ITERATIONS, jj);
 
         for (i = 0; i < nvars; i++) {
-            System.out.printf("x[%3d] = %15.7e \n", i, endpt[i]);
+            l.debug(NLP_X_OPENING_SQR_BRKT + BRACES
+                +   NLP_X_CLOSING_SQR_BRKT + SPACE + BRACES,
+                    String.format(NLP_FORMAT_3D,          i        ),
+                    String.format(NLP_FORMAT_15_POINT_7E, endpt[i]));
         }
 
-        if (fx.compareTo(WOODS) == 0) {
-            System.out.println("True answer: f(1, 1, 1, 1) = 0.");
-        }
+        if (fx.compareTo(WOODS) == 0) { l.debug(NLP_TRUE_ANSWER); }
 
         /*
          * Calculating the objective function value

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesController.java
@@ -3,7 +3,7 @@
  * HookeJeevesController.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -44,7 +44,7 @@ import        com.minimization.nonlinear.unconstrained.hookejeeves.algorithm.Woo
 /**
  * The controller class of the microservice.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 @RestController

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
@@ -3,7 +3,7 @@
  * HookeJeevesControllerHelper.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -38,7 +38,7 @@ import org.bson.Document;
 /**
  * The helper class for the controller and the related ones.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 public class HookeJeevesControllerHelper {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesControllerHelper.java
@@ -43,12 +43,13 @@ import org.bson.Document;
  */
 public class HookeJeevesControllerHelper {
     // Helper constants.
-    public static final String EQUALS   =    "=";
-    public static final String BRACES   =   "{}";
-    public static final String SPACE    =    " ";
-    public static final String V_BAR    =    "|";
-    public static final String DBG_PREF = "==> ";
-    public static final String NEW_LINE = System.lineSeparator();
+    public static final String EMPTY_STRING =     "";
+    public static final String EQUALS       =    "=";
+    public static final String BRACES       =   "{}";
+    public static final String SPACE        =    " ";
+    public static final String V_BAR        =    "|";
+    public static final String DBG_PREF     = "==> ";
+    public static final String NEW_LINE     = System.lineSeparator();
 
     // Extra helper constants.
     private static final int TWELVE = 12;

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojo.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojo.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -19,7 +19,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
 /**
  * The POJO representation, returning in the response.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojo {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoError.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoError.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoError.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The POJO representation, returning in the response
  * when erroneous behavior is occurred.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.6.6
  */
 public class HookeJeevesResponsePojoError {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoInputs.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoInputs.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The &quot;<code>inputs</code>&quot; POJO representation,
  * returning as part of the response POJO.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojoInputs {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoOutput.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesResponsePojoOutput.java
@@ -3,7 +3,7 @@
  * HookeJeevesResponsePojoOutput.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -20,7 +20,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves;
  * The &quot;<code>output</code>&quot; POJO representation,
  * returning as part of the response POJO.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.6.0
  */
 public class HookeJeevesResponsePojoOutput {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
@@ -3,7 +3,7 @@
  * algorithm/HookeJeeves.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -27,7 +27,7 @@ import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesCo
  * The <code>HookeJeeves</code> class contains methods for solving a nonlinear
  * optimization problem using the algorithm of Hooke and Jeeves.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 public class HookeJeeves {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/HookeJeeves.java
@@ -16,6 +16,13 @@
 
 package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesControllerHelper.*;
+
 /**
  * The <code>HookeJeeves</code> class contains methods for solving a nonlinear
  * optimization problem using the algorithm of Hooke and Jeeves.
@@ -24,6 +31,16 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * @since   0.0.1
  */
 public class HookeJeeves {
+    // Helper constants.
+    private static final String NLP_AFTER              = "After";
+    private static final String NLP_FUNEVALS_F_OF_X    = "funevals, f(x) =";
+    private static final String NLP_AT                 = "at";
+    private static final String NLP_FORMAT_5D          = "%5d";
+    private static final String NLP_FORMAT_POINT_4E    = "%.4e";
+    private static final String NLP_X_OPENING_SQR_BRKT = "x[";
+    private static final String NLP_X_CLOSING_SQR_BRKT = "] =";
+    private static final String NLP_FORMAT_2D          = "%2d";
+
     /** The maximum number of variables. */
     public static final int VARS = 250;
 
@@ -32,6 +49,11 @@ public class HookeJeeves {
 
     /** The maximum number of iterations. */
     public static final int IMAX = 5000;
+
+    /** The SLF4J logger. */
+    private static final Logger l = LoggerFactory.getLogger(
+        MethodHandles.lookup().lookupClass()
+    );
 
     /** The number of function evaluations. */
     private int funevals = 0;
@@ -170,11 +192,19 @@ public class HookeJeeves {
             iters++;
              iadj++;
 
-            System.out.printf("\nAfter %5d funevals, f(x) =  %.4e at\n",
-                funevals, fbefore);
+            // Attribution: Keeping the intermediate debug output
+            //              in the original format, taken from Netlib.
+            l.debug(EMPTY_STRING);
+            l.debug(NLP_AFTER + SPACE + BRACES + SPACE + NLP_FUNEVALS_F_OF_X
+                +       SPACE + SPACE + BRACES + SPACE + NLP_AT,
+                        String.format(NLP_FORMAT_5D,       funevals),
+                        String.format(NLP_FORMAT_POINT_4E, fbefore));
 
             for (j = 0; j < nvars; j++) {
-                System.out.printf("   x[%2d] = %.4e\n", j, xbefore[j]);
+                l.debug(SPACE + SPACE + SPACE + NLP_X_OPENING_SQR_BRKT + BRACES
+                    +                           NLP_X_CLOSING_SQR_BRKT + SPACE
+                    +   BRACES, String.format(NLP_FORMAT_2D,      j          ),
+                                String.format(NLP_FORMAT_POINT_4E,xbefore[j]));
             }
 
             // Find best new point, one coord at a time.

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Rosenbrock.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Rosenbrock.java
@@ -3,7 +3,7 @@
  * algorithm/Rosenbrock.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -23,7 +23,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * <br />The objective function in this case is the Rosenbrock's parabolic
  * valley function.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 public final class Rosenbrock {

--- a/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Woods.java
+++ b/src/main/java/com/minimization/nonlinear/unconstrained/hookejeeves/algorithm/Woods.java
@@ -3,7 +3,7 @@
  * algorithm/Woods.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -23,7 +23,7 @@ package com.minimization.nonlinear.unconstrained.hookejeeves.algorithm;
  * <br />The objective function in this case is the so-called
  * &quot;Woods&quot; function.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 public final class Woods {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 # src/main/resources/application.properties
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@
 # src/main/resources/log4j.properties
 # =============================================================================
 # The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
-# Microservice. Version 0.7.3
+# Microservice. Version 0.7.6
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing the nonlinear unconstrained

--- a/src/test/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesAppTests.java
+++ b/src/test/java/com/minimization/nonlinear/unconstrained/hookejeeves/HookeJeevesAppTests.java
@@ -3,7 +3,7 @@
  * HookeJeevesAppTests.java
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained
@@ -29,7 +29,7 @@ import static com.minimization.nonlinear.unconstrained.hookejeeves.HookeJeevesCo
 /**
  * The test class for the microservice.
  *
- * @version 0.7.3
+ * @version 0.7.6
  * @since   0.0.1
  */
 @SpringBootTest

--- a/static/css/doxygen/html-extra-stylesheet.css
+++ b/static/css/doxygen/html-extra-stylesheet.css
@@ -2,7 +2,7 @@
  * static/css/doxygen/html-extra-stylesheet.css
  * ============================================================================
  * The Hooke and Jeeves nonlinear unconstrained minimization algorithm.
- * Microservice. Version 0.7.3
+ * Microservice. Version 0.7.6
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing the nonlinear unconstrained


### PR DESCRIPTION
- Introducing the helper constant **EMPTY_STRING** to eliminate dealing with empty string literals throughout the code.
- _Attribution_: Keeping the intermediate debug output in the original format, taken from **Netlib**.
- Disabling building **Javadoc API docs** temporarily &mdash; this has building issues for now.
- Bumping version number of the app to **0.7.6**.